### PR TITLE
enable deps to show up in changelogs

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -38,6 +38,10 @@
           "section": "Build"
         },
         {
+          "type": "deps",
+          "section": "Dependency Updates"
+        },
+        {
           "type": "ci",
           "hidden": true,
           "section": "CI"

--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,7 @@
     "config:base",
     ":gitSignOff",
     "schedule:nonOfficeHours",
-    ":semanticCommitTypeAll(build)",
-    ":semanticCommitScope(deps)",
+    ":semanticCommitTypeAll(deps)",
     "group:monorepos",
     ":automergePatch"
   ],


### PR DESCRIPTION
### This PR
- makes dependency update PR show up in release changelog to increase transparency to users
- changes Renovate PRs from being prefixed with `build(deps):` to `deps:`