### PR TITLE
chore(operator): Support Progressing state in every phase + refactoring + speed improvements

### DIFF
--- a/operator/api/v1alpha1/common/common.go
+++ b/operator/api/v1alpha1/common/common.go
@@ -51,6 +51,10 @@ func (k KeptnState) IsFailed() bool {
 	return k == StateFailed
 }
 
+func (k KeptnState) IsPending() bool {
+	return k == StatePending
+}
+
 type StatusSummary struct {
 	Total       int
 	progressing int

--- a/operator/api/v1alpha1/keptnappversion_types.go
+++ b/operator/api/v1alpha1/keptnappversion_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/keptn/lifecycle-controller/operator/api/v1alpha1/common"
@@ -204,4 +205,32 @@ func (v KeptnAppVersion) GetDurationMetricsAttributes() []attribute.KeyValue {
 		common.AppVersion.String(v.Spec.Version),
 		common.AppPreviousVersion.String(v.Spec.PreviousVersion),
 	}
+}
+
+func (v KeptnAppVersion) GetState() common.KeptnState {
+	return v.Status.Status
+}
+
+func (v *KeptnAppVersion) SetState(state common.KeptnState) {
+	v.Status.Status = state
+}
+
+func (v KeptnAppVersion) GetCurrentPhase() string {
+	return v.Status.CurrentPhase
+}
+
+func (v *KeptnAppVersion) SetCurrentPhase(phase string) {
+	v.Status.CurrentPhase = phase
+}
+
+func (v *KeptnAppVersion) Complete() {
+	v.SetEndTime()
+}
+
+func (v KeptnAppVersion) GetVersion() string {
+	return v.Spec.Version
+}
+
+func (v KeptnAppVersion) GetSpanName(phase string) string {
+	return fmt.Sprintf("%s.%s.%s.%s", v.Spec.TraceId, v.Spec.AppName, v.Spec.Version, phase)
 }

--- a/operator/api/v1alpha1/keptnworkloadinstance_types.go
+++ b/operator/api/v1alpha1/keptnworkloadinstance_types.go
@@ -242,3 +242,27 @@ func (i KeptnWorkloadInstance) GetIntervalMetricsAttributes() []attribute.KeyVal
 		common.WorkloadPreviousVersion.String(i.Spec.PreviousVersion),
 	}
 }
+
+func (i KeptnWorkloadInstance) GetState() common.KeptnState {
+	return i.Status.Status
+}
+
+func (i *KeptnWorkloadInstance) SetState(state common.KeptnState) {
+	i.Status.Status = state
+}
+
+func (i KeptnWorkloadInstance) GetCurrentPhase() string {
+	return i.Status.CurrentPhase
+}
+
+func (i *KeptnWorkloadInstance) SetCurrentPhase(phase string) {
+	i.Status.CurrentPhase = phase
+}
+
+func (i *KeptnWorkloadInstance) Complete() {
+	i.SetEndTime()
+}
+
+func (i KeptnWorkloadInstance) GetVersion() string {
+	return i.Spec.Version
+}

--- a/operator/api/v1alpha1/keptnworkloadinstance_types.go
+++ b/operator/api/v1alpha1/keptnworkloadinstance_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/keptn/lifecycle-controller/operator/api/v1alpha1/common"
@@ -265,4 +266,8 @@ func (i *KeptnWorkloadInstance) Complete() {
 
 func (i KeptnWorkloadInstance) GetVersion() string {
 	return i.Spec.Version
+}
+
+func (v KeptnWorkloadInstance) GetSpanName(phase string) string {
+	return fmt.Sprintf("%s.%s.%s.%s", v.Spec.TraceId, v.Spec.AppName, v.Spec.Version, phase)
 }

--- a/operator/controllers/common/helperfunctions.go
+++ b/operator/controllers/common/helperfunctions.go
@@ -1,0 +1,32 @@
+package common
+
+import (
+	klcv1alpha1 "github.com/keptn/lifecycle-controller/operator/api/v1alpha1"
+	apicommon "github.com/keptn/lifecycle-controller/operator/api/v1alpha1/common"
+)
+
+func GetTaskStatus(taskName string, instanceStatus []klcv1alpha1.TaskStatus) klcv1alpha1.TaskStatus {
+	for _, status := range instanceStatus {
+		if status.TaskDefinitionName == taskName {
+			return status
+		}
+	}
+	return klcv1alpha1.TaskStatus{
+		TaskDefinitionName: taskName,
+		Status:             apicommon.StatePending,
+		TaskName:           "",
+	}
+}
+
+func GetEvaluationStatus(evaluationName string, instanceStatus []klcv1alpha1.EvaluationStatus) klcv1alpha1.EvaluationStatus {
+	for _, status := range instanceStatus {
+		if status.EvaluationDefinitionName == evaluationName {
+			return status
+		}
+	}
+	return klcv1alpha1.EvaluationStatus{
+		EvaluationDefinitionName: evaluationName,
+		Status:                   apicommon.StatePending,
+		EvaluationName:           "",
+	}
+}

--- a/operator/controllers/common/helperfunctions.go
+++ b/operator/controllers/common/helperfunctions.go
@@ -3,6 +3,7 @@ package common
 import (
 	klcv1alpha1 "github.com/keptn/lifecycle-controller/operator/api/v1alpha1"
 	apicommon "github.com/keptn/lifecycle-controller/operator/api/v1alpha1/common"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func GetTaskStatus(taskName string, instanceStatus []klcv1alpha1.TaskStatus) klcv1alpha1.TaskStatus {
@@ -29,4 +30,8 @@ func GetEvaluationStatus(evaluationName string, instanceStatus []klcv1alpha1.Eva
 		Status:                   apicommon.StatePending,
 		EvaluationName:           "",
 	}
+}
+
+func GetAppVersionName(namespace string, appName string, version string) types.NamespacedName {
+	return types.NamespacedName{Namespace: namespace, Name: appName + "-" + version}
 }

--- a/operator/controllers/common/interfaces.go
+++ b/operator/controllers/common/interfaces.go
@@ -1,0 +1,65 @@
+package common
+
+import (
+	"errors"
+
+	"github.com/keptn/lifecycle-controller/operator/api/v1alpha1/common"
+	"go.opentelemetry.io/otel/attribute"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+//go:generate moq -pkg common_mock --skip-ensure -out ./fake/phaseitem_mock.go . PhaseItem
+type PhaseItem interface {
+	GetState() common.KeptnState
+	SetState(common.KeptnState)
+	GetCurrentPhase() string
+	SetCurrentPhase(string)
+	GetVersion() string
+	GetMetricsAttributes() []attribute.KeyValue
+	GetSpanName(phase string) string
+	Complete()
+}
+
+type PhaseItemWrapper struct {
+	Obj PhaseItem
+}
+
+func NewPhaseItemWrapperFromClientObject(object client.Object) (*PhaseItemWrapper, error) {
+	pi, ok := object.(PhaseItem)
+	if !ok {
+		return nil, errors.New("provided object does not implement PhaseItem interface")
+	}
+	return &PhaseItemWrapper{Obj: pi}, nil
+}
+
+func (pw PhaseItemWrapper) GetState() common.KeptnState {
+	return pw.Obj.GetState()
+}
+
+func (pw *PhaseItemWrapper) SetState(state common.KeptnState) {
+	pw.Obj.SetState(state)
+}
+
+func (pw PhaseItemWrapper) GetCurrentPhase() string {
+	return pw.Obj.GetCurrentPhase()
+}
+
+func (pw *PhaseItemWrapper) SetCurrentPhase(phase string) {
+	pw.Obj.SetCurrentPhase(phase)
+}
+
+func (pw PhaseItemWrapper) GetMetricsAttributes() []attribute.KeyValue {
+	return pw.Obj.GetMetricsAttributes()
+}
+
+func (pw *PhaseItemWrapper) Complete() {
+	pw.Obj.Complete()
+}
+
+func (pw PhaseItemWrapper) GetVersion() string {
+	return pw.Obj.GetVersion()
+}
+
+func (pw PhaseItemWrapper) GetSpanName(phase string) string {
+	return pw.Obj.GetSpanName(phase)
+}

--- a/operator/controllers/common/interfaces_test.go
+++ b/operator/controllers/common/interfaces_test.go
@@ -1,0 +1,26 @@
+package common
+
+import (
+	"github.com/keptn/lifecycle-controller/operator/api/v1alpha1"
+	"github.com/keptn/lifecycle-controller/operator/api/v1alpha1/common"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestPhaseItemWrapper_GetState(t *testing.T) {
+	appVersion := &v1alpha1.KeptnAppVersion{
+		Status: v1alpha1.KeptnAppVersionStatus{
+			Status:       common.StateFailed,
+			CurrentPhase: "test",
+		},
+	}
+
+	object, err := NewPhaseItemWrapperFromClientObject(appVersion)
+	require.Nil(t, err)
+
+	require.Equal(t, "test", object.GetCurrentPhase())
+
+	object.Complete()
+
+	require.NotZero(t, appVersion.Status.EndTime)
+}

--- a/operator/controllers/common/phasehandler.go
+++ b/operator/controllers/common/phasehandler.go
@@ -1,0 +1,115 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/keptn/lifecycle-controller/operator/api/v1alpha1/common"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type PhaseHandler struct {
+	client.Client
+	Recorder    record.EventRecorder
+	Log         logr.Logger
+	bindCRDSpan map[string]trace.Span
+}
+
+type PhaseResult struct {
+	Continue bool
+	ctrl.Result
+}
+
+func RecordEvent(recorder record.EventRecorder, phase common.KeptnPhaseType, eventType string, appVersion client.Object, shortReason string, longReason string, version string) {
+	recorder.Event(appVersion, eventType, fmt.Sprintf("%s%s", phase.ShortName, shortReason), fmt.Sprintf("%s %s / Namespace: %s, Name: %s, Version: %s ", phase.LongName, longReason, appVersion.GetNamespace(), appVersion.GetName(), version))
+}
+
+func (r PhaseHandler) HandlePhase(ctx context.Context, ctxAppTrace context.Context, tracer trace.Tracer, appVersion client.Object, phase common.KeptnPhaseType, span trace.Span, reconcilePhase func() (common.KeptnState, error)) (*PhaseResult, error) {
+	piWrapper, err := NewPhaseItemWrapperFromClientObject(appVersion)
+	if err != nil {
+		return &PhaseResult{Continue: false, Result: ctrl.Result{}}, err
+	}
+	oldStatus := piWrapper.GetState()
+	oldPhase := piWrapper.GetCurrentPhase()
+	piWrapper.SetCurrentPhase(phase.ShortName)
+
+	r.Log.Info(phase.LongName + " not finished")
+	ctxAppTrace, spanAppTrace := r.GetSpan(ctxAppTrace, tracer, appVersion, phase.ShortName)
+
+	state, err := reconcilePhase()
+	if err != nil {
+		spanAppTrace.AddEvent(phase.LongName + " could not get reconciled")
+		RecordEvent(r.Recorder, phase, "Warning", appVersion, "ReconcileErrored", "could not get reconciled", piWrapper.GetVersion())
+		span.SetStatus(codes.Error, err.Error())
+		return &PhaseResult{Continue: false, Result: ctrl.Result{}}, err
+	}
+
+	defer func(oldStatus common.KeptnState, oldPhase string, appVersion client.Object) {
+		piWrapper, _ := NewPhaseItemWrapperFromClientObject(appVersion)
+		if oldStatus != piWrapper.GetState() || oldPhase != piWrapper.GetCurrentPhase() {
+			ctx, spanAppTrace = r.GetSpan(ctxAppTrace, tracer, appVersion, piWrapper.GetCurrentPhase())
+			if err := r.Status().Update(ctx, appVersion); err != nil {
+				r.Log.Error(err, "could not update status")
+			}
+		}
+	}(oldStatus, oldPhase, appVersion)
+
+	if state.IsCompleted() {
+		if state.IsFailed() {
+			piWrapper.Complete()
+			piWrapper.SetState(common.StateFailed)
+			spanAppTrace.AddEvent(phase.LongName + " has failed")
+			spanAppTrace.SetStatus(codes.Error, "Failed")
+			spanAppTrace.End()
+			r.UnbindSpan(appVersion, phase.ShortName)
+			RecordEvent(r.Recorder, phase, "Warning", appVersion, "Failed", "has failed", piWrapper.GetVersion())
+			return &PhaseResult{Continue: false, Result: ctrl.Result{}}, nil
+		}
+
+		piWrapper.SetState(common.StateSucceeded)
+		spanAppTrace.AddEvent(phase.LongName + " has succeeded")
+		spanAppTrace.SetStatus(codes.Ok, "Succeeded")
+		spanAppTrace.End()
+		r.UnbindSpan(appVersion, phase.ShortName)
+		RecordEvent(r.Recorder, phase, "Normal", appVersion, "Succeeded", "has succeeded", piWrapper.GetVersion())
+
+		return &PhaseResult{Continue: true, Result: ctrl.Result{}}, nil
+	}
+
+	piWrapper.SetState(common.StateProgressing)
+	RecordEvent(r.Recorder, phase, "Warning", appVersion, "NotFinished", "has not finished", piWrapper.GetVersion())
+
+	return &PhaseResult{Continue: false, Result: ctrl.Result{Requeue: true, RequeueAfter: 5 * time.Second}}, nil
+}
+
+func (r PhaseHandler) GetSpan(ctx context.Context, tracer trace.Tracer, appv client.Object, phase string) (context.Context, trace.Span) {
+	piWrapper, err := NewPhaseItemWrapperFromClientObject(appv)
+	if err != nil {
+		return nil, nil
+	}
+	appvName := piWrapper.GetSpanName(phase)
+	if r.bindCRDSpan == nil {
+		r.bindCRDSpan = make(map[string]trace.Span)
+	}
+	if span, ok := r.bindCRDSpan[appvName]; ok {
+		return ctx, span
+	}
+	ctx, span := tracer.Start(ctx, phase, trace.WithSpanKind(trace.SpanKindConsumer))
+	r.Log.Info("DEBUG: Created span " + appvName)
+	r.bindCRDSpan[appvName] = span
+	return ctx, span
+}
+
+func (r PhaseHandler) UnbindSpan(appv client.Object, phase string) {
+	piWrapper, err := NewPhaseItemWrapperFromClientObject(appv)
+	if err != nil {
+		return
+	}
+	delete(r.bindCRDSpan, piWrapper.GetSpanName(phase))
+}

--- a/operator/controllers/common/phasehandler.go
+++ b/operator/controllers/common/phasehandler.go
@@ -54,6 +54,10 @@ func (r PhaseHandler) HandlePhase(ctx context.Context, ctxAppTrace context.Conte
 		return &PhaseResult{Continue: false, Result: requeueResult}, err
 	}
 
+	if state.IsPending() {
+		state = common.StateProgressing
+	}
+
 	defer func(oldStatus common.KeptnState, oldPhase string, reconcileObject client.Object) {
 		piWrapper, _ := NewPhaseItemWrapperFromClientObject(reconcileObject)
 		if oldStatus != piWrapper.GetState() || oldPhase != piWrapper.GetCurrentPhase() {

--- a/operator/controllers/common/phasehandler.go
+++ b/operator/controllers/common/phasehandler.go
@@ -34,7 +34,7 @@ func (r PhaseHandler) HandlePhase(ctx context.Context, ctxAppTrace context.Conte
 	requeueResult := ctrl.Result{Requeue: true, RequeueAfter: 5 * time.Second}
 	piWrapper, err := NewPhaseItemWrapperFromClientObject(reconcileObject)
 	if err != nil {
-		return &PhaseResult{Continue: false, Result: requeueResult}, err
+		return &PhaseResult{Continue: false, Result: ctrl.Result{Requeue: true}}, err
 	}
 	oldStatus := piWrapper.GetState()
 	oldPhase := piWrapper.GetCurrentPhase()

--- a/operator/controllers/common/spanhandler.go
+++ b/operator/controllers/common/spanhandler.go
@@ -1,0 +1,38 @@
+package common
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/trace"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type SpanHandler struct {
+	bindCRDSpan map[string]trace.Span
+}
+
+func (r SpanHandler) GetSpan(ctx context.Context, tracer trace.Tracer, appv client.Object, phase string) (context.Context, trace.Span) {
+	piWrapper, err := NewPhaseItemWrapperFromClientObject(appv)
+	if err != nil {
+		return nil, nil
+	}
+	appvName := piWrapper.GetSpanName(phase)
+	if r.bindCRDSpan == nil {
+		r.bindCRDSpan = make(map[string]trace.Span)
+	}
+	if span, ok := r.bindCRDSpan[appvName]; ok {
+		return ctx, span
+	}
+	ctx, span := tracer.Start(ctx, phase, trace.WithSpanKind(trace.SpanKindConsumer))
+	r.bindCRDSpan[appvName] = span
+	return ctx, span
+}
+
+func (r SpanHandler) UnbindSpan(appv client.Object, phase string) error {
+	piWrapper, err := NewPhaseItemWrapperFromClientObject(appv)
+	if err != nil {
+		return err
+	}
+	delete(r.bindCRDSpan, piWrapper.GetSpanName(phase))
+	return nil
+}

--- a/operator/controllers/common/spanhandler.go
+++ b/operator/controllers/common/spanhandler.go
@@ -11,25 +11,25 @@ type SpanHandler struct {
 	bindCRDSpan map[string]trace.Span
 }
 
-func (r SpanHandler) GetSpan(ctx context.Context, tracer trace.Tracer, appv client.Object, phase string) (context.Context, trace.Span) {
-	piWrapper, err := NewPhaseItemWrapperFromClientObject(appv)
+func (r SpanHandler) GetSpan(ctx context.Context, tracer trace.Tracer, reconcileObject client.Object, phase string) (context.Context, trace.Span, error) {
+	piWrapper, err := NewPhaseItemWrapperFromClientObject(reconcileObject)
 	if err != nil {
-		return nil, nil
+		return nil, nil, err
 	}
 	appvName := piWrapper.GetSpanName(phase)
 	if r.bindCRDSpan == nil {
 		r.bindCRDSpan = make(map[string]trace.Span)
 	}
 	if span, ok := r.bindCRDSpan[appvName]; ok {
-		return ctx, span
+		return ctx, span, nil
 	}
 	ctx, span := tracer.Start(ctx, phase, trace.WithSpanKind(trace.SpanKindConsumer))
 	r.bindCRDSpan[appvName] = span
-	return ctx, span
+	return ctx, span, nil
 }
 
-func (r SpanHandler) UnbindSpan(appv client.Object, phase string) error {
-	piWrapper, err := NewPhaseItemWrapperFromClientObject(appv)
+func (r SpanHandler) UnbindSpan(reconcileObject client.Object, phase string) error {
+	piWrapper, err := NewPhaseItemWrapperFromClientObject(reconcileObject)
 	if err != nil {
 		return err
 	}

--- a/operator/controllers/keptnapp/controller.go
+++ b/operator/controllers/keptnapp/controller.go
@@ -19,6 +19,7 @@ package keptnapp
 import (
 	"context"
 	"fmt"
+
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 

--- a/operator/controllers/keptnappversion/controller.go
+++ b/operator/controllers/keptnappversion/controller.go
@@ -77,7 +77,7 @@ func (r *KeptnAppVersionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	appVersion := &klcv1alpha1.KeptnAppVersion{}
 	err := r.Get(ctx, req.NamespacedName, appVersion)
 	if errors.IsNotFound(err) {
-		return reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
+		return reconcile.Result{}, nil
 	}
 
 	if err != nil {

--- a/operator/controllers/keptnappversion/controller.go
+++ b/operator/controllers/keptnappversion/controller.go
@@ -19,8 +19,11 @@ package keptnappversion
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/types"
 	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	controllercommon "github.com/keptn/lifecycle-controller/operator/controllers/common"
 
 	"github.com/keptn/lifecycle-controller/operator/api/v1alpha1/semconv"
 	"go.opentelemetry.io/otel/codes"
@@ -44,13 +47,12 @@ import (
 
 // KeptnAppVersionReconciler reconciles a KeptnAppVersion object
 type KeptnAppVersionReconciler struct {
+	Scheme *runtime.Scheme
 	client.Client
-	Scheme      *runtime.Scheme
-	Log         logr.Logger
-	Recorder    record.EventRecorder
-	Tracer      trace.Tracer
-	Meters      common.KeptnMeters
-	bindCRDSpan map[string]trace.Span
+	Log      logr.Logger
+	Recorder record.EventRecorder
+	Tracer   trace.Tracer
+	Meters   common.KeptnMeters
 }
 
 //+kubebuilder:rbac:groups=lifecycle.keptn.sh,resources=keptnappversions,verbs=get;list;watch;create;update;patch;delete
@@ -91,27 +93,44 @@ func (r *KeptnAppVersionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	ctxAppTrace := otel.GetTextMapPropagator().Extract(context.TODO(), appTraceContextCarrier)
 
 	ctx, span := r.Tracer.Start(ctx, "reconcile_app_version", trace.WithSpanKind(trace.SpanKindConsumer))
-	defer span.End()
+
+	defer func(span trace.Span, appVersion *klcv1alpha1.KeptnAppVersion) {
+		r.Log.Info("Increasing app count")
+		if appVersion.IsEndTimeSet() {
+			attrs := appVersion.GetMetricsAttributes()
+			r.Meters.AppCount.Add(ctx, 1, attrs...)
+		}
+		span.End()
+	}(span, appVersion)
 
 	semconv.AddAttributeFromAppVersion(span, *appVersion)
 
 	phase := common.PhaseAppPreDeployment
 
+	phaseHandler := controllercommon.PhaseHandler{
+		Client:   r.Client,
+		Recorder: r.Recorder,
+		Log:      r.Log,
+	}
+
 	if appVersion.Status.CurrentPhase == "" {
-		r.unbindSpan(appVersion, phase.ShortName)
+		phaseHandler.UnbindSpan(appVersion, phase.ShortName)
 		var spanAppTrace trace.Span
-		ctxAppTrace, spanAppTrace = r.getSpan(ctxAppTrace, appVersion, phase.ShortName)
+		ctxAppTrace, spanAppTrace = phaseHandler.GetSpan(ctxAppTrace, r.Tracer, appVersion, phase.ShortName)
 
 		semconv.AddAttributeFromAppVersion(spanAppTrace, *appVersion)
 		spanAppTrace.AddEvent("App Version Pre-Deployment Tasks started", trace.WithTimestamp(time.Now()))
-		r.recordEvent(phase, "Normal", appVersion, "Started", "have started")
+		controllercommon.RecordEvent(r.Recorder, phase, "Normal", appVersion, "Started", "have started", appVersion.GetVersion())
 	}
 
 	if !appVersion.IsPreDeploymentSucceeded() {
 		reconcilePreDep := func() (common.KeptnState, error) {
 			return r.reconcilePrePostDeployment(ctx, appVersion, common.PreDeploymentCheckType)
 		}
-		return r.handlePhase(ctx, ctxAppTrace, appVersion, phase, span, appVersion.IsPreDeploymentFailed, reconcilePreDep)
+		result, err := phaseHandler.HandlePhase(ctx, ctxAppTrace, r.Tracer, appVersion, phase, span, reconcilePreDep)
+		if !result.Continue {
+			return result.Result, err
+		}
 	}
 
 	phase = common.PhaseAppPreEvaluation
@@ -119,7 +138,10 @@ func (r *KeptnAppVersionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		reconcilePreEval := func() (common.KeptnState, error) {
 			return r.reconcilePrePostEvaluation(ctx, appVersion, common.PreDeploymentEvaluationCheckType)
 		}
-		return r.handlePhase(ctx, ctxAppTrace, appVersion, phase, span, appVersion.IsPreDeploymentEvaluationFailed, reconcilePreEval)
+		result, err := phaseHandler.HandlePhase(ctx, ctxAppTrace, r.Tracer, appVersion, phase, span, reconcilePreEval)
+		if !result.Continue {
+			return result.Result, err
+		}
 	}
 
 	phase = common.PhaseAppDeployment
@@ -127,8 +149,10 @@ func (r *KeptnAppVersionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		reconcileAppDep := func() (common.KeptnState, error) {
 			return r.reconcileWorkloads(ctx, appVersion)
 		}
-		return r.handlePhase(ctx, ctxAppTrace, appVersion, phase, span, appVersion.AreWorkloadsFailed, reconcileAppDep)
-
+		result, err := phaseHandler.HandlePhase(ctx, ctxAppTrace, r.Tracer, appVersion, phase, span, reconcileAppDep)
+		if !result.Continue {
+			return result.Result, err
+		}
 	}
 
 	phase = common.PhaseAppPostDeployment
@@ -136,7 +160,10 @@ func (r *KeptnAppVersionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		reconcilePostDep := func() (common.KeptnState, error) {
 			return r.reconcilePrePostDeployment(ctx, appVersion, common.PostDeploymentCheckType)
 		}
-		return r.handlePhase(ctx, ctxAppTrace, appVersion, phase, span, appVersion.IsPostDeploymentFailed, reconcilePostDep)
+		result, err := phaseHandler.HandlePhase(ctx, ctxAppTrace, r.Tracer, appVersion, phase, span, reconcilePostDep)
+		if !result.Continue {
+			return result.Result, err
+		}
 	}
 
 	phase = common.PhaseAppPostEvaluation
@@ -144,10 +171,13 @@ func (r *KeptnAppVersionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		reconcilePostEval := func() (common.KeptnState, error) {
 			return r.reconcilePrePostEvaluation(ctx, appVersion, common.PostDeploymentEvaluationCheckType)
 		}
-		return r.handlePhase(ctx, ctxAppTrace, appVersion, phase, span, appVersion.IsPostDeploymentEvaluationFailed, reconcilePostEval)
+		result, err := phaseHandler.HandlePhase(ctx, ctxAppTrace, r.Tracer, appVersion, phase, span, reconcilePostEval)
+		if !result.Continue {
+			return result.Result, err
+		}
 	}
 
-	r.recordEvent(phase, "Normal", appVersion, "Finished", "is finished")
+	controllercommon.RecordEvent(r.Recorder, phase, "Normal", appVersion, "Finished", "is finished", appVersion.GetVersion())
 	err = r.Client.Status().Update(ctx, appVersion)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
@@ -168,11 +198,6 @@ func (r *KeptnAppVersionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	attrs := appVersion.GetMetricsAttributes()
 
-	r.Log.Info("Increasing app count")
-
-	// metrics: increment app counter
-	r.Meters.AppCount.Add(ctx, 1, attrs...)
-
 	// metrics: add app duration
 	duration := appVersion.Status.EndTime.Time.Sub(appVersion.Status.StartTime.Time)
 	r.Meters.AppDuration.Record(ctx, duration.Seconds(), attrs...)
@@ -185,99 +210,6 @@ func (r *KeptnAppVersionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&klcv1alpha1.KeptnAppVersion{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
-}
-
-func (r *KeptnAppVersionReconciler) recordEvent(phase common.KeptnPhaseType, eventType string, appVersion *klcv1alpha1.KeptnAppVersion, shortReason string, longReason string) {
-	r.Recorder.Event(appVersion, eventType, fmt.Sprintf("%s%s", phase.ShortName, shortReason), fmt.Sprintf("%s %s / Namespace: %s, Name: %s, Version: %s ", phase.LongName, longReason, appVersion.Namespace, appVersion.Name, appVersion.Spec.Version))
-}
-
-func (r *KeptnAppVersionReconciler) handlePhase(ctx context.Context, ctxAppTrace context.Context, appVersion *klcv1alpha1.KeptnAppVersion, phase common.KeptnPhaseType, span trace.Span, phaseFailed func() bool, reconcilePhase func() (common.KeptnState, error)) (ctrl.Result, error) {
-
-	oldStatus := appVersion.Status.Status
-	newStatus := oldStatus
-	statusUpdated := false
-
-	r.Log.Info(phase.LongName + " not finished")
-	ctxAppTrace, spanAppTrace := r.getSpan(ctxAppTrace, appVersion, phase.ShortName)
-
-	oldPhase := appVersion.Status.CurrentPhase
-	appVersion.Status.CurrentPhase = phase.ShortName
-	if phaseFailed() { //TODO eventually we should decide whether a task returns FAILED, currently we never have this status set
-		r.recordEvent(phase, "Warning", appVersion, "Failed", "has failed")
-		return ctrl.Result{Requeue: true, RequeueAfter: 60 * time.Second}, nil
-	}
-	state, err := reconcilePhase()
-	if err != nil {
-		spanAppTrace.AddEvent(phase.LongName + " could not get reconciled")
-		r.recordEvent(phase, "Warning", appVersion, "ReconcileErrored", "could not get reconciled")
-		span.SetStatus(codes.Error, err.Error())
-		return ctrl.Result{Requeue: true}, err
-	}
-	if state.IsSucceeded() {
-		newStatus = common.StateSucceeded
-		spanAppTrace.AddEvent(phase.LongName + " has succeeded")
-		spanAppTrace.SetStatus(codes.Ok, "Succeeded")
-		spanAppTrace.End()
-		r.unbindSpan(appVersion, phase.ShortName)
-		r.recordEvent(phase, "Normal", appVersion, "Succeeded", "has succeeded")
-	} else if state.IsFailed() {
-
-		appVersion.SetEndTime()
-		attrs := appVersion.GetMetricsAttributes()
-		r.Meters.AppCount.Add(ctx, 1, attrs...)
-
-		newStatus = common.StateFailed
-
-		spanAppTrace.AddEvent(phase.LongName + " has failed")
-		spanAppTrace.SetStatus(codes.Error, "Failed")
-		spanAppTrace.End()
-		r.unbindSpan(appVersion, phase.ShortName)
-
-		r.recordEvent(phase, "Warning", appVersion, "Failed", "has failed")
-	} else {
-		newStatus = common.StateProgressing
-		r.recordEvent(phase, "Warning", appVersion, "NotFinished", "has not finished")
-	}
-
-	// check if status changed
-	if oldPhase != appVersion.Status.CurrentPhase {
-		ctx, spanAppTrace = r.getSpan(ctxAppTrace, appVersion, appVersion.Status.CurrentPhase)
-		semconv.AddAttributeFromAppVersion(spanAppTrace, *appVersion)
-		statusUpdated = true
-	}
-	if oldStatus != newStatus {
-		appVersion.Status.Status = newStatus
-		statusUpdated = true
-	}
-
-	if statusUpdated {
-		if err := r.Status().Update(ctx, appVersion); err != nil {
-			r.Log.Error(err, "could not update status")
-		}
-	}
-	return ctrl.Result{Requeue: true, RequeueAfter: 5 * time.Second}, nil
-}
-
-func (r *KeptnAppVersionReconciler) getSpanName(appv *klcv1alpha1.KeptnAppVersion, phase string) string {
-	return fmt.Sprintf("%s.%s.%s.%s", appv.Spec.TraceId, appv.Spec.AppName, appv.Spec.Version, phase)
-}
-
-func (r *KeptnAppVersionReconciler) getSpan(ctx context.Context, appv *klcv1alpha1.KeptnAppVersion, phase string) (context.Context, trace.Span) {
-	appvName := r.getSpanName(appv, phase)
-	if r.bindCRDSpan == nil {
-		r.bindCRDSpan = make(map[string]trace.Span)
-	}
-	if span, ok := r.bindCRDSpan[appvName]; ok {
-		return ctx, span
-	}
-	ctx, span := r.Tracer.Start(ctx, phase, trace.WithSpanKind(trace.SpanKindConsumer))
-	r.Log.Info("DEBUG: Created span " + appvName)
-	r.bindCRDSpan[appvName] = span
-	return ctx, span
-}
-
-func (r *KeptnAppVersionReconciler) unbindSpan(appv *klcv1alpha1.KeptnAppVersion, phase string) {
-	delete(r.bindCRDSpan, r.getSpanName(appv, phase))
 }
 
 func (r *KeptnAppVersionReconciler) GetActiveApps(ctx context.Context) ([]common.GaugeValue, error) {

--- a/operator/controllers/keptnappversion/controller.go
+++ b/operator/controllers/keptnappversion/controller.go
@@ -77,7 +77,7 @@ func (r *KeptnAppVersionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	appVersion := &klcv1alpha1.KeptnAppVersion{}
 	err := r.Get(ctx, req.NamespacedName, appVersion)
 	if errors.IsNotFound(err) {
-		return reconcile.Result{}, nil
+		return reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
 	}
 
 	if err != nil {
@@ -96,8 +96,8 @@ func (r *KeptnAppVersionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	ctx, span := r.Tracer.Start(ctx, "reconcile_app_version", trace.WithSpanKind(trace.SpanKindConsumer))
 
 	defer func(span trace.Span, appVersion *klcv1alpha1.KeptnAppVersion) {
-		r.Log.Info("Increasing app count")
 		if appVersion.IsEndTimeSet() {
+			r.Log.Info("Increasing app count")
 			attrs := appVersion.GetMetricsAttributes()
 			r.Meters.AppCount.Add(ctx, 1, attrs...)
 		}

--- a/operator/controllers/keptnappversion/controller.go
+++ b/operator/controllers/keptnappversion/controller.go
@@ -120,7 +120,10 @@ func (r *KeptnAppVersionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			r.Log.Error(err, "cannot unbind span")
 		}
 		var spanAppTrace trace.Span
-		ctxAppTrace, spanAppTrace = r.SpanHandler.GetSpan(ctxAppTrace, r.Tracer, appVersion, phase.ShortName)
+		ctxAppTrace, spanAppTrace, err = r.SpanHandler.GetSpan(ctxAppTrace, r.Tracer, appVersion, phase.ShortName)
+		if err != nil {
+			r.Log.Error(err, "could not get span")
+		}
 
 		semconv.AddAttributeFromAppVersion(spanAppTrace, *appVersion)
 		spanAppTrace.AddEvent("App Version Pre-Deployment Tasks started", trace.WithTimestamp(time.Now()))

--- a/operator/controllers/keptnappversion/reconcile_prepostdeployment.go
+++ b/operator/controllers/keptnappversion/reconcile_prepostdeployment.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/keptn/lifecycle-controller/operator/api/v1alpha1/semconv"
+	controllercommon "github.com/keptn/lifecycle-controller/operator/controllers/common"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
@@ -76,7 +77,7 @@ func (r *KeptnAppVersionReconciler) reconcileTasks(ctx context.Context, checkTyp
 		taskExists := false
 
 		if oldstatus != taskStatus.Status {
-			r.recordEvent(phase, "Normal", appVersion, "TaskStatusChanged", fmt.Sprintf("task status changed from %s to %s", oldstatus, taskStatus.Status))
+			controllercommon.RecordEvent(r.Recorder, phase, "Normal", appVersion, "TaskStatusChanged", fmt.Sprintf("task status changed from %s to %s", oldstatus, taskStatus.Status), appVersion.GetVersion())
 		}
 
 		// Check if task has already succeeded or failed
@@ -119,7 +120,7 @@ func (r *KeptnAppVersionReconciler) reconcileTasks(ctx context.Context, checkTyp
 		summary = common.UpdateStatusSummary(ns.Status, summary)
 	}
 	if common.GetOverallState(summary) != common.StateSucceeded {
-		r.recordEvent(phase, "Warning", appVersion, "NotFinished", "has not finished")
+		controllercommon.RecordEvent(r.Recorder, phase, "Warning", appVersion, "NotFinished", "has not finished", appVersion.GetVersion())
 	}
 	return newStatus, summary, nil
 }
@@ -163,10 +164,10 @@ func (r *KeptnAppVersionReconciler) createKeptnTask(ctx context.Context, namespa
 	err = r.Client.Create(ctx, newTask)
 	if err != nil {
 		r.Log.Error(err, "could not create KeptnTask")
-		r.recordEvent(phase, "Warning", appVersion, "CreateFailed", "could not create KeptnTask")
+		controllercommon.RecordEvent(r.Recorder, phase, "Warning", appVersion, "CreateFailed", "could not create KeptnTask", appVersion.GetVersion())
 		return "", err
 	}
-	r.recordEvent(phase, "Normal", appVersion, "Created", "created")
+	controllercommon.RecordEvent(r.Recorder, phase, "Normal", appVersion, "Created", "created", appVersion.GetVersion())
 
 	return newTask.Name, nil
 }

--- a/operator/controllers/keptnappversion/reconcile_prepostdeployment.go
+++ b/operator/controllers/keptnappversion/reconcile_prepostdeployment.go
@@ -72,7 +72,7 @@ func (r *KeptnAppVersionReconciler) reconcileTasks(ctx context.Context, checkTyp
 			}
 		}
 
-		taskStatus := GetTaskStatus(taskDefinitionName, statuses)
+		taskStatus := controllercommon.GetTaskStatus(taskDefinitionName, statuses)
 		task := &klcv1alpha1.KeptnTask{}
 		taskExists := false
 
@@ -170,17 +170,4 @@ func (r *KeptnAppVersionReconciler) createKeptnTask(ctx context.Context, namespa
 	controllercommon.RecordEvent(r.Recorder, phase, "Normal", appVersion, "Created", "created", appVersion.GetVersion())
 
 	return newTask.Name, nil
-}
-
-func GetTaskStatus(taskName string, instanceStatus []klcv1alpha1.TaskStatus) klcv1alpha1.TaskStatus {
-	for _, status := range instanceStatus {
-		if status.TaskDefinitionName == taskName {
-			return status
-		}
-	}
-	return klcv1alpha1.TaskStatus{
-		TaskDefinitionName: taskName,
-		Status:             common.StatePending,
-		TaskName:           "",
-	}
 }

--- a/operator/controllers/keptnappversion/reconcile_prepostevaluation.go
+++ b/operator/controllers/keptnappversion/reconcile_prepostevaluation.go
@@ -72,7 +72,7 @@ func (r *KeptnAppVersionReconciler) reconcileEvaluations(ctx context.Context, ch
 			}
 		}
 
-		evaluationStatus := GetEvaluationStatus(evaluationName, statuses)
+		evaluationStatus := controllercommon.GetEvaluationStatus(evaluationName, statuses)
 		evaluation := &klcv1alpha1.KeptnEvaluation{}
 		evaluationExists := false
 
@@ -171,17 +171,4 @@ func (r *KeptnAppVersionReconciler) createKeptnEvaluation(ctx context.Context, n
 	controllercommon.RecordEvent(r.Recorder, phase, "Normal", appVersion, "Created", "created", appVersion.GetVersion())
 
 	return newEvaluation.Name, nil
-}
-
-func GetEvaluationStatus(evaluationName string, instanceStatus []klcv1alpha1.EvaluationStatus) klcv1alpha1.EvaluationStatus {
-	for _, status := range instanceStatus {
-		if status.EvaluationDefinitionName == evaluationName {
-			return status
-		}
-	}
-	return klcv1alpha1.EvaluationStatus{
-		EvaluationDefinitionName: evaluationName,
-		Status:                   common.StatePending,
-		EvaluationName:           "",
-	}
 }

--- a/operator/controllers/keptnappversion/reconcile_prepostevaluation.go
+++ b/operator/controllers/keptnappversion/reconcile_prepostevaluation.go
@@ -8,6 +8,7 @@ import (
 	klcv1alpha1 "github.com/keptn/lifecycle-controller/operator/api/v1alpha1"
 	"github.com/keptn/lifecycle-controller/operator/api/v1alpha1/common"
 	"github.com/keptn/lifecycle-controller/operator/api/v1alpha1/semconv"
+	controllercommon "github.com/keptn/lifecycle-controller/operator/controllers/common"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
@@ -76,7 +77,7 @@ func (r *KeptnAppVersionReconciler) reconcileEvaluations(ctx context.Context, ch
 		evaluationExists := false
 
 		if oldstatus != evaluationStatus.Status {
-			r.recordEvent(phase, "Normal", appVersion, "EvaluationStatusChanged", fmt.Sprintf("evaluation status changed from %s to %s", oldstatus, evaluationStatus.Status))
+			controllercommon.RecordEvent(r.Recorder, phase, "Normal", appVersion, "EvaluationStatusChanged", fmt.Sprintf("evaluation status changed from %s to %s", oldstatus, evaluationStatus.Status), appVersion.GetVersion())
 		}
 
 		// Check if evaluation has already succeeded or failed
@@ -119,7 +120,7 @@ func (r *KeptnAppVersionReconciler) reconcileEvaluations(ctx context.Context, ch
 		summary = common.UpdateStatusSummary(ns.Status, summary)
 	}
 	if common.GetOverallState(summary) != common.StateSucceeded {
-		r.recordEvent(phase, "Warning", appVersion, "NotFinished", "has not finished")
+		controllercommon.RecordEvent(r.Recorder, phase, "Warning", appVersion, "NotFinished", "has not finished", appVersion.GetVersion())
 	}
 	return newStatus, summary, nil
 }
@@ -164,10 +165,10 @@ func (r *KeptnAppVersionReconciler) createKeptnEvaluation(ctx context.Context, n
 	err = r.Client.Create(ctx, newEvaluation)
 	if err != nil {
 		r.Log.Error(err, "could not create KeptnEvaluation")
-		r.recordEvent(phase, "Warning", appVersion, "CreateFailed", "could not create KeptnEvaluation")
+		controllercommon.RecordEvent(r.Recorder, phase, "Warning", appVersion, "CreateFailed", "could not create KeptnEvaluation", appVersion.GetVersion())
 		return "", err
 	}
-	r.recordEvent(phase, "Normal", appVersion, "Created", "created")
+	controllercommon.RecordEvent(r.Recorder, phase, "Normal", appVersion, "Created", "created", appVersion.GetVersion())
 
 	return newEvaluation.Name, nil
 }

--- a/operator/controllers/keptnevaluation/controller.go
+++ b/operator/controllers/keptnevaluation/controller.go
@@ -147,7 +147,7 @@ func (r *KeptnEvaluationReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		if common.GetOverallState(statusSummary) == common.StateSucceeded {
 			evaluation.Status.OverallStatus = common.StateSucceeded
 		} else {
-			evaluation.Status.OverallStatus = common.StatePending
+			evaluation.Status.OverallStatus = common.StateProgressing
 		}
 
 	}

--- a/operator/controllers/keptnevaluation/controller.go
+++ b/operator/controllers/keptnevaluation/controller.go
@@ -83,7 +83,7 @@ func (r *KeptnEvaluationReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, nil
 		}
 		r.Log.Error(err, "Failed to get the KeptnEvaluation")
-		return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, nil
+		return ctrl.Result{}, nil
 	}
 
 	traceContextCarrier := propagation.MapCarrier(evaluation.Annotations)
@@ -114,7 +114,7 @@ func (r *KeptnEvaluationReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		if err != nil {
 			if errors.IsNotFound(err) {
 				r.Log.Info(err.Error() + ", ignoring error since object must be deleted")
-				return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, nil
+				return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
 			}
 			r.Log.Error(err, "Failed to retrieve a resource")
 			return ctrl.Result{}, nil

--- a/operator/controllers/keptnworkloadinstance/controller.go
+++ b/operator/controllers/keptnworkloadinstance/controller.go
@@ -169,7 +169,10 @@ func (r *KeptnWorkloadInstanceReconciler) Reconcile(ctx context.Context, req ctr
 			r.Log.Error(err, "cannot unbind span")
 		}
 		var spanAppTrace trace.Span
-		ctxAppTrace, spanAppTrace = r.SpanHandler.GetSpan(ctxAppTrace, r.Tracer, workloadInstance, phase.ShortName)
+		ctxAppTrace, spanAppTrace, err = r.SpanHandler.GetSpan(ctxAppTrace, r.Tracer, workloadInstance, phase.ShortName)
+		if err != nil {
+			r.Log.Error(err, "could not get span")
+		}
 		semconv.AddAttributeFromAppVersion(spanAppTrace, appVersion)
 		spanAppTrace.AddEvent("WorkloadInstance Pre-Deployment Tasks started", trace.WithTimestamp(time.Now()))
 		controllercommon.RecordEvent(r.Recorder, phase, "Normal", workloadInstance, "Started", "have started", workloadInstance.GetVersion())

--- a/operator/controllers/keptnworkloadinstance/controller.go
+++ b/operator/controllers/keptnworkloadinstance/controller.go
@@ -30,7 +30,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/go-logr/logr"
-	"github.com/google/uuid"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -284,15 +283,6 @@ func (r *KeptnWorkloadInstanceReconciler) SetupWithManager(mgr ctrl.Manager) err
 		Complete(r)
 }
 
-func (r *KeptnWorkloadInstanceReconciler) generateSuffix() string {
-	uid := uuid.New().String()
-	return uid[:10]
-}
-
-func GetAppVersionName(namespace string, appName string, version string) types.NamespacedName {
-	return types.NamespacedName{Namespace: namespace, Name: appName + "-" + version}
-}
-
 func (r *KeptnWorkloadInstanceReconciler) getAppVersion(ctx context.Context, appName types.NamespacedName) (*klcv1alpha1.KeptnAppVersion, error) {
 	app := &klcv1alpha1.KeptnApp{}
 	err := r.Get(ctx, appName, app)
@@ -301,7 +291,7 @@ func (r *KeptnWorkloadInstanceReconciler) getAppVersion(ctx context.Context, app
 	}
 
 	appVersion := &klcv1alpha1.KeptnAppVersion{}
-	err = r.Get(ctx, GetAppVersionName(appName.Namespace, appName.Name, app.Spec.Version), appVersion)
+	err = r.Get(ctx, controllercommon.GetAppVersionName(appName.Namespace, appName.Name, app.Spec.Version), appVersion)
 	return appVersion, err
 }
 

--- a/operator/controllers/keptnworkloadinstance/controller.go
+++ b/operator/controllers/keptnworkloadinstance/controller.go
@@ -83,7 +83,7 @@ func (r *KeptnWorkloadInstanceReconciler) Reconcile(ctx context.Context, req ctr
 	workloadInstance := &klcv1alpha1.KeptnWorkloadInstance{}
 	err := r.Get(ctx, req.NamespacedName, workloadInstance)
 	if errors.IsNotFound(err) {
-		return reconcile.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
+		return reconcile.Result{}, nil
 	}
 
 	if err != nil {

--- a/operator/controllers/keptnworkloadinstance/reconcile_deploymentstate.go
+++ b/operator/controllers/keptnworkloadinstance/reconcile_deploymentstate.go
@@ -2,6 +2,7 @@ package keptnworkloadinstance
 
 import (
 	"context"
+
 	klcv1alpha1 "github.com/keptn/lifecycle-controller/operator/api/v1alpha1"
 	"github.com/keptn/lifecycle-controller/operator/api/v1alpha1/common"
 	appsv1 "k8s.io/api/apps/v1"

--- a/operator/controllers/keptnworkloadinstance/reconcile_deploymentstate.go
+++ b/operator/controllers/keptnworkloadinstance/reconcile_deploymentstate.go
@@ -14,51 +14,52 @@ import (
 
 func (r *KeptnWorkloadInstanceReconciler) reconcileDeployment(ctx context.Context, workloadInstance *klcv1alpha1.KeptnWorkloadInstance) (common.KeptnState, error) {
 	if workloadInstance.Spec.ResourceReference.Kind == "Pod" {
-
 		isPodRunning, err := r.isPodRunning(ctx, workloadInstance.Spec.ResourceReference, workloadInstance.Namespace)
 		if err != nil {
 			return common.StateUnknown, err
 		}
 		if isPodRunning {
 			workloadInstance.Status.DeploymentStatus = common.StateSucceeded
+		} else {
+			workloadInstance.Status.DeploymentStatus = common.StateProgressing
+		}
+	} else {
+		isReplicaRunning, err := r.isReplicaSetRunning(ctx, workloadInstance.Spec.ResourceReference, workloadInstance.Namespace)
+		if err != nil {
+			return common.StateUnknown, err
+		}
+		if isReplicaRunning {
+			workloadInstance.Status.DeploymentStatus = common.StateSucceeded
+		} else {
+			workloadInstance.Status.DeploymentStatus = common.StateProgressing
 		}
 	}
 
-	isReplicaRunning, count, err := r.isReplicaSetRunning(ctx, workloadInstance.Spec.ResourceReference, workloadInstance.Namespace)
-	if err != nil {
-		return common.StateUnknown, err
-	}
-	if isReplicaRunning {
-		workloadInstance.Status.DeploymentStatus = common.StateSucceeded
-	} else if count > 0 {
-		workloadInstance.Status.DeploymentStatus = common.StateProgressing
-	}
-
-	err = r.Client.Status().Update(ctx, workloadInstance)
+	err := r.Client.Status().Update(ctx, workloadInstance)
 	if err != nil {
 		return common.StateUnknown, err
 	}
 	return workloadInstance.Status.DeploymentStatus, nil
 }
 
-func (r *KeptnWorkloadInstanceReconciler) isReplicaSetRunning(ctx context.Context, resource klcv1alpha1.ResourceReference, namespace string) (bool, int32, error) {
+func (r *KeptnWorkloadInstanceReconciler) isReplicaSetRunning(ctx context.Context, resource klcv1alpha1.ResourceReference, namespace string) (bool, error) {
 	replica := &appsv1.ReplicaSetList{}
 	if err := r.Client.List(ctx, replica, client.InNamespace(namespace)); err != nil {
-		return false, 0, err
+		return false, err
 	}
 	for _, re := range replica.Items {
 		if re.UID == resource.UID {
 			replicas, err := r.getDesiredReplicas(ctx, re.OwnerReferences[0], namespace)
 			if err != nil {
-				return false, re.Status.ReadyReplicas, err
+				return false, err
 			}
 			if re.Status.ReadyReplicas == replicas {
-				return true, re.Status.ReadyReplicas, nil
+				return true, nil
 			}
-			return false, re.Status.ReadyReplicas, nil
+			return false, nil
 		}
 	}
-	return false, 0, nil
+	return false, nil
 
 }
 

--- a/operator/controllers/keptnworkloadinstance/reconcile_prepostdeployment.go
+++ b/operator/controllers/keptnworkloadinstance/reconcile_prepostdeployment.go
@@ -7,6 +7,7 @@ import (
 	klcv1alpha1 "github.com/keptn/lifecycle-controller/operator/api/v1alpha1"
 	"github.com/keptn/lifecycle-controller/operator/api/v1alpha1/common"
 	"github.com/keptn/lifecycle-controller/operator/api/v1alpha1/semconv"
+	controllercommon "github.com/keptn/lifecycle-controller/operator/controllers/common"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
@@ -126,7 +127,7 @@ func (r *KeptnWorkloadInstanceReconciler) reconcileTasks(ctx context.Context, ch
 		taskExists := false
 
 		if oldstatus != taskStatus.Status {
-			r.recordEvent(phase, "Normal", workloadInstance, "TaskStatusChanged", fmt.Sprintf("task status changed from %s to %s", oldstatus, taskStatus.Status))
+			controllercommon.RecordEvent(r.Recorder, phase, "Normal", workloadInstance, "TaskStatusChanged", fmt.Sprintf("task status changed from %s to %s", oldstatus, taskStatus.Status), workloadInstance.GetVersion())
 		}
 
 		// Check if task has already succeeded or failed

--- a/operator/controllers/keptnworkloadinstance/reconcile_prepostevaluation.go
+++ b/operator/controllers/keptnworkloadinstance/reconcile_prepostevaluation.go
@@ -72,7 +72,7 @@ func (r *KeptnWorkloadInstanceReconciler) reconcileEvaluations(ctx context.Conte
 			}
 		}
 
-		evaluationStatus := GetEvaluationStatus(evaluationName, statuses)
+		evaluationStatus := controllercommon.GetEvaluationStatus(evaluationName, statuses)
 		evaluation := &klcv1alpha1.KeptnEvaluation{}
 		evaluationExists := false
 
@@ -171,17 +171,4 @@ func (r *KeptnWorkloadInstanceReconciler) createKeptnEvaluation(ctx context.Cont
 	controllercommon.RecordEvent(r.Recorder, phase, "Normal", workloadInstance, "Created", "created", workloadInstance.GetVersion())
 
 	return newEvaluation.Name, nil
-}
-
-func GetEvaluationStatus(evaluationName string, instanceStatus []klcv1alpha1.EvaluationStatus) klcv1alpha1.EvaluationStatus {
-	for _, status := range instanceStatus {
-		if status.EvaluationDefinitionName == evaluationName {
-			return status
-		}
-	}
-	return klcv1alpha1.EvaluationStatus{
-		EvaluationDefinitionName: evaluationName,
-		Status:                   common.StatePending,
-		EvaluationName:           "",
-	}
 }

--- a/operator/controllers/keptnworkloadinstance/reconcile_prepostevaluation.go
+++ b/operator/controllers/keptnworkloadinstance/reconcile_prepostevaluation.go
@@ -8,6 +8,7 @@ import (
 	klcv1alpha1 "github.com/keptn/lifecycle-controller/operator/api/v1alpha1"
 	"github.com/keptn/lifecycle-controller/operator/api/v1alpha1/common"
 	"github.com/keptn/lifecycle-controller/operator/api/v1alpha1/semconv"
+	controllercommon "github.com/keptn/lifecycle-controller/operator/controllers/common"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
@@ -76,7 +77,7 @@ func (r *KeptnWorkloadInstanceReconciler) reconcileEvaluations(ctx context.Conte
 		evaluationExists := false
 
 		if oldstatus != evaluationStatus.Status {
-			r.recordEvent(phase, "Normal", workloadInstance, "EvaluationStatusChanged", fmt.Sprintf("evaluation status changed from %s to %s", oldstatus, evaluationStatus.Status))
+			controllercommon.RecordEvent(r.Recorder, phase, "Normal", workloadInstance, "EvaluationStatusChanged", fmt.Sprintf("evaluation status changed from %s to %s", oldstatus, evaluationStatus.Status), workloadInstance.GetVersion())
 		}
 
 		// Check if evaluation has already succeeded or failed
@@ -119,7 +120,7 @@ func (r *KeptnWorkloadInstanceReconciler) reconcileEvaluations(ctx context.Conte
 		summary = common.UpdateStatusSummary(ns.Status, summary)
 	}
 	if common.GetOverallState(summary) != common.StateSucceeded {
-		r.recordEvent(phase, "Warning", workloadInstance, "NotFinished", "has not finished")
+		controllercommon.RecordEvent(r.Recorder, phase, "Warning", workloadInstance, "NotFinished", "has not finished", workloadInstance.GetVersion())
 	}
 	return newStatus, summary, nil
 }
@@ -164,10 +165,10 @@ func (r *KeptnWorkloadInstanceReconciler) createKeptnEvaluation(ctx context.Cont
 	err = r.Client.Create(ctx, newEvaluation)
 	if err != nil {
 		r.Log.Error(err, "could not create KeptnEvaluation")
-		r.recordEvent(phase, "Warning", workloadInstance, "CreateFailed", "could not create KeptnEvaluation")
+		controllercommon.RecordEvent(r.Recorder, phase, "Warning", workloadInstance, "CreateFailed", "could not create KeptnEvaluation", workloadInstance.GetVersion())
 		return "", err
 	}
-	r.recordEvent(phase, "Normal", workloadInstance, "Created", "created")
+	controllercommon.RecordEvent(r.Recorder, phase, "Normal", workloadInstance, "Created", "created", workloadInstance.GetVersion())
 
 	return newEvaluation.Name, nil
 }

--- a/operator/main.go
+++ b/operator/main.go
@@ -50,6 +50,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 
+	controllercommon "github.com/keptn/lifecycle-controller/operator/controllers/common"
+
 	"os"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
@@ -251,6 +253,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	spanHandler := controllercommon.SpanHandler{}
+
 	if !disableWebhook {
 		mgr.GetWebhookServer().Register("/mutate-v1-pod", &webhook.Admission{
 			Handler: &webhooks.PodMutatingWebhook{
@@ -309,12 +313,13 @@ func main() {
 	}
 
 	workloadInstanceReconciler := &keptnworkloadinstance.KeptnWorkloadInstanceReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Log:      ctrl.Log.WithName("KeptnWorkloadInstance Controller"),
-		Recorder: mgr.GetEventRecorderFor("keptnworkloadinstance-controller"),
-		Meters:   meters,
-		Tracer:   otel.Tracer("keptn/operator/workloadinstance"),
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		Log:         ctrl.Log.WithName("KeptnWorkloadInstance Controller"),
+		Recorder:    mgr.GetEventRecorderFor("keptnworkloadinstance-controller"),
+		Meters:      meters,
+		Tracer:      otel.Tracer("keptn/operator/workloadinstance"),
+		SpanHandler: spanHandler,
 	}
 	if err = (workloadInstanceReconciler).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KeptnWorkloadInstance")
@@ -322,12 +327,13 @@ func main() {
 	}
 
 	appVersionReconciler := &keptnappversion.KeptnAppVersionReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Log:      ctrl.Log.WithName("KeptnAppVersion Controller"),
-		Recorder: mgr.GetEventRecorderFor("keptnappversion-controller"),
-		Tracer:   otel.Tracer("keptn/operator/appversion"),
-		Meters:   meters,
+		Client:      mgr.GetClient(),
+		Scheme:      mgr.GetScheme(),
+		Log:         ctrl.Log.WithName("KeptnAppVersion Controller"),
+		Recorder:    mgr.GetEventRecorderFor("keptnappversion-controller"),
+		Tracer:      otel.Tracer("keptn/operator/appversion"),
+		Meters:      meters,
+		SpanHandler: spanHandler,
 	}
 	if err = (appVersionReconciler).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KeptnAppVersion")


### PR DESCRIPTION
- refactored handling of the phase -> common code for KeptnAppVersion and KeptnWorkloadInstance
- support `Progressing` state in each phase
- improved speed of the whole cycle (30-40s improvement on deploying podtatohead observability example 2:30min -> 1:45min)
- move duplicated code to controller common package